### PR TITLE
[WIP] Abstract differentiation interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,15 @@ authors = ["Mohamed Tarek <mohamed82008@gmail.com> and contributors"]
 version = "0.1.0"
 
 [deps]
+ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 julia = "1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "FiniteDifferences"]

--- a/Project.toml
+++ b/Project.toml
@@ -3,11 +3,15 @@ uuid = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"
 authors = ["Mohamed Tarek <mohamed82008@gmail.com> and contributors"]
 version = "0.1.0"
 
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
 [compat]
 julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 
 [targets]
-test = ["Test"]
+test = ["Test", "FiniteDifferences"]

--- a/src/AbstractDifferentiation.jl
+++ b/src/AbstractDifferentiation.jl
@@ -1,5 +1,332 @@
 module AbstractDifferentiation
 
-# Write your package code here.
+using LinearAlgebra
+
+export AD
+
+const AD = AbstractDifferentiation
+
+abstract type AbstractBackend end
+abstract type AbstractFiniteDifference <: AbstractBackend end
+abstract type AbstractForwardMode <: AbstractBackend end
+abstract type AbstractReverseMode <: AbstractBackend end
+
+struct HigherOrderBackend{B} <: AbstractBackend
+    backends::B
+end
+reduceorder(b::AbstractBackend) = b
+function reduceorder(b::HigherOrderBackend)
+    return HigherOrderBackend(reverse(Base.tail(reverse(b.backends))))
+end
+lowest(b::AbstractBackend) = b
+lowest(b::HigherOrderBackend) = b.backends[end]
+secondlowest(b::HigherOrderBackend) = lowest(reduceorder(b))
+
+# If the primal value is in y, extract it.
+# Otherwise, re-compute it, e.g. in finite diff.
+primalvalue(::AbstractFiniteDifference, ::Any, f, xs) = f(xs...)
+primalvalue(::AbstractBackend, ys, ::Any, ::Any) = primalvalue(ys)
+primalvalue(x::Tuple) = map(primalvalue, x)
+primalvalue(x) = x
+
+function derivative(ab::AbstractBackend, f, xs::Number...)
+    return getindex.(jacobian(lowest(ab), f, xs...), 1)
+end
+function gradient(ab::AbstractBackend, f, xs...)
+    return adjoint.(jacobian(lowest(ab), f, xs...))
+end
+function jacobian(ab::AbstractBackend, f, xs...) end
+function hessian(ab::AbstractBackend, f, xs...)
+    return jacobian(secondlowest(ab), (xs...,) -> begin
+        gradient(lowest(ab), f, xs...)
+    end, xs...)
+end
+
+function value_and_derivative(ab::AbstractBackend, f, xs::Number...)
+    value, jacs = value_and_jacobian(lowest(ab), f, xs...)
+    return value[1], getindex.(jacs, 1)
+end
+function value_and_gradient(ab::AbstractBackend, f, xs...)
+    value, jacs = value_and_jacobian(lowest(ab), f, xs...)
+    return value, adjoint.(jacs)
+end
+function value_and_jacobian(ab::AbstractBackend, f, xs...)
+    local value
+    primalcalled = false
+    jacs = jacobian(lowest(ab), (_xs...,) -> begin
+        v = f(_xs...)
+        if !primalcalled
+            value = primalvalue(ab, v, f, xs)
+            primalcalled = true
+        end
+        return v
+    end, xs...)
+    return value, jacs
+end
+function value_and_hessian(ab::AbstractBackend, f, xs...)
+    local value
+    primalcalled = false
+    hess = jacobian(secondlowest(ab), (_xs...,) -> begin
+        v, g = value_and_gradient(lowest(ab), f, _xs...)
+        if !primalcalled
+            value = primalvalue(ab, v, f, xs)
+            primalcalled = true
+        end
+        return g
+    end, xs...)
+    return value, hess
+end
+function value_and_hessian(ab::HigherOrderBackend, f, xs...)
+    local value
+    primalcalled = false
+    hess = jacobian(secondlowest(ab), (_xs...,) -> begin
+        v, g = value_and_gradient(lowest(ab), f, _xs...)
+        if !primalcalled
+            value = primalvalue(ab, v, f, xs)
+            primalcalled = true
+        end
+        return g
+    end, xs...)
+    return value, hess
+end
+function value_gradient_and_hessian(ab::AbstractBackend, f, xs...)
+    local value
+    primalcalled = false
+    grads, hess = value_and_jacobian(secondlowest(ab), (_xs...,) -> begin
+        v, g = value_and_gradient(lowest(ab), f, _xs...)
+        if !primalcalled
+            value = primalvalue(secondlowest(ab), v, f, xs)
+            primalcalled = false
+        end
+        return g
+    end, xs...)
+    return value, grads, hess
+end
+function value_gradient_and_hessian(ab::HigherOrderBackend, f, xs...)
+    local value
+    primalcalled = false
+    grads, hess = value_and_jacobian(secondlowest(ab), (_xs...,) -> begin
+        v, g = value_and_gradient(lowest(ab), f, _xs...)
+        if !primalcalled
+            value = primalvalue(secondlowest(ab), v, f, xs)
+            primalcalled = true
+        end
+        return g
+    end, xs...)
+    return value, grads, hess
+end
+
+function pushforward_function(
+    ab::AbstractBackend,
+    f,
+    xs::Union{Number, AbstractArray{<:Number}}...,
+)
+    return (ds) -> begin
+        return jacobian(lowest(ab), (xds...,) -> begin
+            if ds isa Tuple
+                @assert length(xs) == length(ds)
+                newxs = xs .+ ds .* xds
+                return f(newxs...)
+            else
+                @assert length(xs) == length(xds) == 1
+                newx = xs[1] + ds * xds[1]
+                return f(newx)
+            end
+        end, _zero.(xs, ds)...)
+    end
+end
+function value_and_pushforward_function(
+    ab::AbstractBackend,
+    f,
+    xs::Union{Number, AbstractArray{<:Number}}...,
+)
+    return (ds) -> begin
+        @assert ds isa Tuple && length(ds) == length(xs)
+        return value_and_jacobian(lowest(ab), (xds...,) -> begin
+            if ds isa Tuple
+                @assert length(xs) == length(ds)
+                newxs = xs .+ ds .* xds
+                return f(newxs...)
+            else
+                @assert length(xs) == length(xds) == 1
+                newx = xs[1] + ds * xds[1]
+                return f(newx)
+            end
+        end, _zero.(xs, ds)...)
+    end
+end
+
+_zero(::Number, d::Number) = zero(d)
+_zero(::Number, d::AbstractVector) = zero(d)
+_zero(::AbstractVector, d::AbstractVector) = zero(eltype(d))
+_zero(::AbstractVector, d::AbstractMatrix) = zero(similar(d, size(d, 2)))
+_zero(::AbstractMatrix, d::AbstractMatrix) = zero(d)
+_zero(::Any, d::Any) = zero(d)
+
+function pullback_function(ab::AbstractBackend, f, xs...)
+    return (ws) -> begin
+        jacs = jacobian(lowest(ab), (xs...,) -> begin
+            vs = f(xs...)
+            if ws isa Tuple
+                @assert length(vs) == length(ws)
+                return sum(zip(vs, ws)) do v, w
+                    if w isa Union{AbstractMatrix, UniformScaling} && v isa AbstractVector
+                        return w' * v
+                    else
+                        # for arbitrary arrays
+                        return dot(w, v)
+                    end
+                end
+            else
+                w, v = ws, vs
+                if w isa Union{AbstractMatrix, UniformScaling} && v isa AbstractVector
+                    return w' * v
+                else
+                    # for arbitrary arrays
+                    return dot(w, v)
+                end
+            end
+        end, xs...)
+        return adjoint.(jacs)
+    end
+end
+function value_and_pullback_function(
+    ab::AbstractBackend,
+    f,
+    xs...,
+)
+    return (ws) -> begin
+        local value
+        primalcalled = false
+        jacs = jacobian(lowest(ab), (_xs...,) -> begin
+            vs = f(_xs...)
+            if !primalcalled
+                value = primalvalue(lowest(ab), vs, f, xs)
+                primalcalled = true
+            end
+            if ws isa Tuple
+                @assert length(vs) == length(ws)
+                return sum(zip(vs, ws)) do v, w
+                    if w isa Union{AbstractMatrix, UniformScaling} && v isa AbstractVector
+                        return w' * v
+                    else
+                        # for arbitrary arrays
+                        return dot(w, v)
+                    end
+                end
+            else
+                w, v = ws, vs
+                if w isa Union{AbstractMatrix, UniformScaling} && v isa AbstractVector
+                    return w' * v
+                else
+                    # for arbitrary arrays
+                    return dot(w, v)
+                end
+            end
+        end, xs...)
+        return value, adjoint.(jacs)
+    end
+end
+
+struct LazyDerivative{B, F, X}
+    backend::B
+    f::F
+    xs::X
+end
+function Base.:*(d::LazyDerivative, y)
+    return derivative(d.ab, d.f, d.xs...) * y
+end
+function Base.:*(y, d::LazyDerivative)
+    return y * derivative(d.ab, d.f, d.xs...)
+end
+
+struct LazyGradient{B, F, X}
+    backend::B
+    f::F
+    xs::X
+end
+Base.:*(d::LazyGradient, y) = gradient(d.ab, d.f, d.xs...) * y
+Base.:*(y, d::LazyGradient) = y * gradient(d.ab, d.f, d.xs...)
+
+struct LazyJacobian{B, F, X}
+    backend::B
+    f::F
+    xs::X
+end
+function Base.:*(d::LazyJacobian, ys)
+    return pushforward_function(d.ab, d.f, d.xs...)(ys)
+end
+function Base.:*(ys, d::LazyJacobian)
+    if ys isa Tuple
+        ya = adjoint.(ys)
+    else
+        ya = adjoint(ys)
+    end
+    return pullback_function(d.ab, d.f, d.xs...)(ya)
+end
+
+struct LazyHessian{B, F, X}
+    backend::B
+    f::F
+    xs::X
+end
+function Base.:*(d::LazyHessian, ys)
+    return pushforward_function(
+        secondlowest(d.ab),
+        (xs...,) -> gradient(lowest(d.ab), d.f, xs...),
+        d.xs...,
+    )(ys)
+end
+function Base.:*(ys, d::LazyHessian)
+    if ys isa Tuple
+        ya = adjoint.(ys)
+    else
+        ya = adjoint(ys)
+    end
+    return pullback_function(
+        secondlowest(d.ab),
+        (xs...,) -> gradient(lowest(d.ab), d.f, xs...),
+        d.xs...,
+    )(ya)
+end
+
+function lazyderivative(ab::AbstractBackend, f, xs::Number...)
+    return LazyDerivative(ab, f, xs)
+end
+function lazygradient(ab::AbstractBackend, f, xs...)
+    return LazyGradient(ab, f, xs)
+end
+function lazyhessian(ab::AbstractBackend, f, xs...)
+    return LazyHessian(ab, f, xs)
+end
+function lazyjacobian(ab::AbstractBackend, f, xs...)
+    return LazyJacobian(ab, f, xs)
+end
+
+struct D{B, F}
+    backend::B
+    f::F
+end
+D(b::AbstractBackend, d::D) = H(HigherOrderBackend((b, d.b)), d.f)
+D(d::D) = H(HigherOrderBackend((d.backend, d.backend)), d.f)
+function (d::D)(xs...; lazy = true)
+    if lazy
+        return lazyjacobian(d.ab, d.f, xs...)
+    else
+        return jacobian(d.ab, d.f, xs...)
+    end
+end
+
+struct H{B, F}
+    backend::B
+    f::F
+end
+function (h::H)(xs...; lazy = true)
+    if lazy
+        return lazyhessian(h.ab, h.f, xs...)
+    else
+        return hessian(h.ab, h.f, xs...)
+    end
+end
 
 end

--- a/src/AbstractDifferentiation.jl
+++ b/src/AbstractDifferentiation.jl
@@ -96,7 +96,7 @@ function value_gradient_and_hessian(ab::AbstractBackend, f, xs...)
         v, g = value_and_gradient(lowest(ab), f, _xs...)
         if !primalcalled
             value = primalvalue(secondlowest(ab), v, f, xs)
-            primalcalled = false
+            primalcalled = true
         end
         return g
     end, xs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,79 @@
 using AbstractDifferentiation
-using Test
+using Test, FiniteDifferences, LinearAlgebra
+
+const FDM = FiniteDifferences
+struct FDMBackend{A} <: AD.AbstractFiniteDifference
+    alg::A
+end
+FDMBackend() = FDMBackend(central_fdm(5, 1))
+const fdm_backend = FDMBackend()
+
+# Minimal interface
+function AD.jacobian(ab::FDMBackend, f, xs...)
+    return jacobian(ab.alg, f, xs...)
+end
+
+fder(x, y) = exp(y) * x + y * log(x)
+fgrad(x, y) = prod(x) + sum(y ./ (1:length(y)))
+function fjac(x, y)
+    x + Bidiagonal(-ones(length(y)) * 3, ones(length(y) - 1) / 2, :U) * y
+end
+
+const xscalar = rand()
+const yscalar = rand()
+
+const xvec = rand(5)
+const yvec = rand(5)
 
 @testset "AbstractDifferentiation.jl" begin
-    # Write your tests here.
+    @testset "FiniteDifferences" begin
+        @testset "Derivative" begin
+            der1 = AD.derivative(fdm_backend, fder, xscalar, yscalar)
+            der2 = (
+                fdm_backend.alg(x -> fder(x, yscalar), xscalar),
+                fdm_backend.alg(y -> fder(xscalar, y), yscalar),
+            )
+            @test norm.(der1 .- der2) == (0, 0)
+            valscalar, der3 = AD.value_and_derivative(fdm_backend, fder, xscalar, yscalar)
+            @test valscalar == fder(xscalar, yscalar)
+            @test der3 .- der1 == (0, 0)
+        end
+        @testset "Gradient" begin
+            grad1 = AD.gradient(fdm_backend, fgrad, xvec, yvec)
+            grad2 = FDM.grad(fdm_backend.alg, fgrad, xvec, yvec)
+            @test norm.(grad1 .- grad2) == (0, 0)
+            valscalar, grad3 = AD.value_and_gradient(fdm_backend, fgrad, xvec, yvec)
+            @test valscalar == fgrad(xvec, yvec)
+            @test norm.(grad3 .- grad1) == (0, 0)
+        end
+        @testset "Jacobian" begin
+            jac1 = AD.jacobian(fdm_backend, fjac, xvec, yvec)
+            jac2 = FDM.jacobian(fdm_backend.alg, fjac, xvec, yvec)
+            @test norm.(jac1 .- jac2) == (0, 0)
+            valvec, jac3 = AD.value_and_jacobian(fdm_backend, fjac, xvec, yvec)
+            @test valvec == fjac(xvec, yvec)
+            @test norm.(jac3 .- jac1) == (0, 0)
+        end
+        @testset "jvp" begin
+            v = (rand(length(xvec)), rand(length(yvec)))
+            pf1 = AD.pushforward_function(fdm_backend, fjac, xvec, yvec)(v)
+            pf2 = (
+                FDM.jvp(fdm_backend.alg, x -> fjac(x, yvec), (xvec, v[1])),
+                FDM.jvp(fdm_backend.alg, y -> fjac(xvec, y), (yvec, v[2])),
+            )
+            @test norm.(pf1 .- pf2) == (0, 0)
+            valvec, pf3 = AD.value_and_pushforward_function(fdm_backend, fjac, xvec, yvec)(v)
+            @test valvec == fjac(xvec, yvec)
+            @test norm.(pf3 .- pf1) == (0, 0)
+        end
+        @testset "j′vp" begin
+            w = rand(length(fjac(xvec, yvec)))
+            pb1 = AD.pullback_function(fdm_backend, fjac, xvec, yvec)(w)
+            pb2 = FDM.j′vp(fdm_backend.alg, fjac, w, xvec, yvec)
+            @test all(norm.(pb1 .- pb2) .<= (1e-10, 1e-10))
+            valvec, pb3 = AD.value_and_pullback_function(fdm_backend, fjac, xvec, yvec)(w)
+            @test valvec == fjac(xvec, yvec)
+            @test norm.(pb3 .- pb1) == (0, 0)
+        end
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,15 +2,37 @@ using AbstractDifferentiation
 using Test, FiniteDifferences, LinearAlgebra
 
 const FDM = FiniteDifferences
-struct FDMBackend{A} <: AD.AbstractFiniteDifference
+
+struct FDMBackend1{A} <: AD.AbstractFiniteDifference
     alg::A
 end
-FDMBackend() = FDMBackend(central_fdm(5, 1))
-const fdm_backend = FDMBackend()
-
+FDMBackend1() = FDMBackend1(central_fdm(5, 1))
+const fdm_backend1 = FDMBackend1()
 # Minimal interface
-function AD.jacobian(ab::FDMBackend, f, xs...)
+AD.@primitive function jacobian(ab::FDMBackend1, f, xs...)
     return jacobian(ab.alg, f, xs...)
+end
+
+struct FDMBackend2{A} <: AD.AbstractFiniteDifference
+    alg::A
+end
+FDMBackend2() = FDMBackend2(central_fdm(5, 1))
+const fdm_backend2 = FDMBackend2()
+AD.@primitive function pushforward_function(ab::FDMBackend2, f, xs...)
+    return (vs) -> jvp(ab.alg, f, tuple.(xs, vs)...)
+end
+
+struct FDMBackend3{A} <: AD.AbstractFiniteDifference
+    alg::A
+end
+FDMBackend3() = FDMBackend3(central_fdm(5, 1))
+const fdm_backend3 = FDMBackend3()
+AD.@primitive function pullback_function(ab::FDMBackend3, f, xs...)
+    return function (vs)
+        # Supports only single output
+        @assert length(vs) == 1
+        return j′vp(ab.alg, f, vs[1], xs...)
+    end
 end
 
 fder(x, y) = exp(y) * x + y * log(x)
@@ -25,55 +47,121 @@ const yscalar = rand()
 const xvec = rand(5)
 const yvec = rand(5)
 
+function test_fdm_derivatives(fdm_backend)
+    der1 = AD.derivative(fdm_backend, fder, xscalar, yscalar)
+    der2 = (
+        fdm_backend.alg(x -> fder(x, yscalar), xscalar),
+        fdm_backend.alg(y -> fder(xscalar, y), yscalar),
+    )
+    @test norm.(der1 .- der2) == (0, 0)
+    valscalar, der3 = AD.value_and_derivative(fdm_backend, fder, xscalar, yscalar)
+    @test valscalar == fder(xscalar, yscalar)
+    @test der3 .- der1 == (0, 0)
+end
+
+function test_fdm_gradients(fdm_backend)
+    grad1 = AD.gradient(fdm_backend, fgrad, xvec, yvec)
+    grad2 = FDM.grad(fdm_backend.alg, fgrad, xvec, yvec)
+    @test norm.(grad1 .- grad2) == (0, 0)
+    valscalar, grad3 = AD.value_and_gradient(fdm_backend, fgrad, xvec, yvec)
+    @test valscalar == fgrad(xvec, yvec)
+    @test norm.(grad3 .- grad1) == (0, 0)
+end
+
+function test_fdm_jacobians(fdm_backend)
+    jac1 = AD.jacobian(fdm_backend, fjac, xvec, yvec)
+    jac2 = FDM.jacobian(fdm_backend.alg, fjac, xvec, yvec)
+    @test norm.(jac1 .- jac2) == (0, 0)
+    valvec, jac3 = AD.value_and_jacobian(fdm_backend, fjac, xvec, yvec)
+    @test valvec == fjac(xvec, yvec)
+    @test norm.(jac3 .- jac1) == (0, 0)
+end
+
+function test_fdm_hessians(fdm_backend)
+    fhess = x -> fgrad(x, yvec)
+    hess1 = AD.hessian(fdm_backend, fhess, xvec)
+    hess2 = FDM.jacobian(
+        fdm_backend.alg,
+        (x) -> begin
+            FDM.grad(
+                fdm_backend.alg,
+                fhess,
+                x,
+            )
+        end,
+        xvec,
+    )
+    @test norm.(hess1 .- hess2) == (0,)
+    valscalar, hess3 = AD.value_and_hessian(fdm_backend, fhess, xvec)
+    @test valscalar == fgrad(xvec, yvec)
+    @test norm.(hess3 .- hess1) == (0,)
+    valscalar, grad, hess4 = AD.value_gradient_and_hessian(fdm_backend, fhess, xvec)
+    @test valscalar == fgrad(xvec, yvec)
+    @test norm.(grad .- AD.gradient(fdm_backend, fhess, xvec)) == (0,)
+    @test norm.(hess4 .- hess1) == (0,)
+end
+
+function test_fdm_jvp(fdm_backend)
+    v = (rand(length(xvec)), rand(length(yvec)))
+    pf1 = AD.pushforward_function(fdm_backend, fjac, xvec, yvec)(v)
+    pf2 = (
+        FDM.jvp(fdm_backend.alg, x -> fjac(x, yvec), (xvec, v[1])),
+        FDM.jvp(fdm_backend.alg, y -> fjac(xvec, y), (yvec, v[2])),
+    )
+    @test norm.(pf1 .- pf2) == (0, 0)
+    valvec, pf3 = AD.value_and_pushforward_function(fdm_backend, fjac, xvec, yvec)(v)
+    @test valvec == fjac(xvec, yvec)
+    @test norm.(pf3 .- pf1) == (0, 0)
+end
+
+function test_fdm_j′vp(fdm_backend)
+    w = rand(length(fjac(xvec, yvec)))
+    pb1 = AD.pullback_function(fdm_backend, fjac, xvec, yvec)(w)
+    pb2 = FDM.j′vp(fdm_backend.alg, fjac, w, xvec, yvec)
+    @test all(norm.(pb1 .- pb2) .<= (1e-10, 1e-10))
+    valvec, pb3 = AD.value_and_pullback_function(fdm_backend, fjac, xvec, yvec)(w)
+    @test valvec == fjac(xvec, yvec)
+    @test norm.(pb3 .- pb1) == (0, 0)
+end
+
 @testset "AbstractDifferentiation.jl" begin
     @testset "FiniteDifferences" begin
         @testset "Derivative" begin
-            der1 = AD.derivative(fdm_backend, fder, xscalar, yscalar)
-            der2 = (
-                fdm_backend.alg(x -> fder(x, yscalar), xscalar),
-                fdm_backend.alg(y -> fder(xscalar, y), yscalar),
-            )
-            @test norm.(der1 .- der2) == (0, 0)
-            valscalar, der3 = AD.value_and_derivative(fdm_backend, fder, xscalar, yscalar)
-            @test valscalar == fder(xscalar, yscalar)
-            @test der3 .- der1 == (0, 0)
+            test_fdm_derivatives(fdm_backend1)
+            test_fdm_derivatives(fdm_backend2)
+            test_fdm_derivatives(fdm_backend3)
         end
         @testset "Gradient" begin
-            grad1 = AD.gradient(fdm_backend, fgrad, xvec, yvec)
-            grad2 = FDM.grad(fdm_backend.alg, fgrad, xvec, yvec)
-            @test norm.(grad1 .- grad2) == (0, 0)
-            valscalar, grad3 = AD.value_and_gradient(fdm_backend, fgrad, xvec, yvec)
-            @test valscalar == fgrad(xvec, yvec)
-            @test norm.(grad3 .- grad1) == (0, 0)
+            test_fdm_gradients(fdm_backend1)
+            test_fdm_gradients(fdm_backend2)
+            test_fdm_gradients(fdm_backend3)
         end
         @testset "Jacobian" begin
-            jac1 = AD.jacobian(fdm_backend, fjac, xvec, yvec)
-            jac2 = FDM.jacobian(fdm_backend.alg, fjac, xvec, yvec)
-            @test norm.(jac1 .- jac2) == (0, 0)
-            valvec, jac3 = AD.value_and_jacobian(fdm_backend, fjac, xvec, yvec)
-            @test valvec == fjac(xvec, yvec)
-            @test norm.(jac3 .- jac1) == (0, 0)
+            test_fdm_jacobians(fdm_backend1)
+            test_fdm_jacobians(fdm_backend2)
+            # Errors
+            test_fdm_jacobians(fdm_backend3)
+        end
+        @testset "Hessian" begin
+            # Works but super slow
+            test_fdm_hessians(fdm_backend1)
+            # Errors
+            test_fdm_hessians(fdm_backend2)
+            # Errors
+            test_fdm_hessians(fdm_backend3)
         end
         @testset "jvp" begin
-            v = (rand(length(xvec)), rand(length(yvec)))
-            pf1 = AD.pushforward_function(fdm_backend, fjac, xvec, yvec)(v)
-            pf2 = (
-                FDM.jvp(fdm_backend.alg, x -> fjac(x, yvec), (xvec, v[1])),
-                FDM.jvp(fdm_backend.alg, y -> fjac(xvec, y), (yvec, v[2])),
-            )
-            @test norm.(pf1 .- pf2) == (0, 0)
-            valvec, pf3 = AD.value_and_pushforward_function(fdm_backend, fjac, xvec, yvec)(v)
-            @test valvec == fjac(xvec, yvec)
-            @test norm.(pf3 .- pf1) == (0, 0)
+            test_fdm_jvp(fdm_backend1)
+            # Errors
+            test_fdm_jvp(fdm_backend2)
+            # Errors
+            test_fdm_jvp(fdm_backend3)
         end
         @testset "j′vp" begin
-            w = rand(length(fjac(xvec, yvec)))
-            pb1 = AD.pullback_function(fdm_backend, fjac, xvec, yvec)(w)
-            pb2 = FDM.j′vp(fdm_backend.alg, fjac, w, xvec, yvec)
-            @test all(norm.(pb1 .- pb2) .<= (1e-10, 1e-10))
-            valvec, pb3 = AD.value_and_pullback_function(fdm_backend, fjac, xvec, yvec)(w)
-            @test valvec == fjac(xvec, yvec)
-            @test norm.(pb3 .- pb1) == (0, 0)
+            test_fdm_j′vp(fdm_backend1)
+            test_fdm_j′vp(fdm_backend2)
+            # Errors
+            test_fdm_j′vp(fdm_backend3)
         end
     end
 end


### PR DESCRIPTION
In this PR, I implement a high level API for differentiation. The idea is to unify the APIs of all the AD packages we have in the Julia ecosystem. This should enable AD users to write backend-agnostic code using only the API from `AbstractDifferentiation`.

In the current implementation, AD package authors would need to define at least the following:
1. A backend struct e.g. `PackageBackend` for the package that subtypes `AbstractBackend`
2. `jacobian(ab::PackageBackend, f, xs...)`: returns the Jacobian of the output(s) of `f` wrt its inputs at `xs`.
3. `primalvalue(x)` (not needed for finite difference or source to source): returns the primal value of `x`. `x` can be a dual number, vector of duals, tracked array, etc.

By defining the above, the following functions are all then automatically defined:
1. `derivative(::AbstractBackend, f, xs...)`: returns the derivatives of the scalar-valued function `f` wrt its inputs at `xs` where `xs` are all scalars.
2. `gradient(ab::AbstractBackend, f, xs...)`: returns the gradient of the scalar-valued function `f` wrt its inputs at `xs` where `xs` can be anything that the backend `ab` supports.
3. `hessian(ab::AbstractBackend, f, xs...)`: returns the Hessian of the scalar-valued function `f` wrt its inputs at `xs`.
4. `value_and_derivative(::AbstractBackend, f, xs...)`: returns the output value of the function `f` as well as its derivatives wrt its inputs at `xs`.
5. `value_and_gradient(::AbstractBackend, f, xs...)`: returns the output value of the function `f` as well as its gradients wrt its inputs at `xs`.
6. `value_and_jacobian(::AbstractBackend, f, xs...)`: returns the output value of the function `f` as well as its Jacobians wrt its inputs at `xs`.
7. `value_and_hessian(ab::AbstractBackend, f, xs...)`: returns the output value of the function `f` as well as its Hessian wrt its inputs at `xs`.
8. `value_gradient_and_hessian(ab::AbstractBackend, f, xs...)`: returns the output value of the function `f` as well as its gradients and Hessians wrt its inputs at `xs`.
9. `pullback_function(::AbstractBackend, f, xs...)`: returns the pullback function of `f` at `xs` .
10. `pushforward_function(::AbstractBackend, f, xs...)`: returns the pushforward function of `f` at `xs`.
11. `value_and_pullback_function(::AbstractBackend, f, xs...)`: returns a function that takes as input the differential of `f` and returns the primal value of `f` at `xs` and the pullback of the differential.
12. `value_and_pushforward_function(::AbstractBackend, f, xs...)`: returns a function that takes as input the tangents of the inputs `xs` and returns the primal value of `f` at `xs` and the pushforward of the tangents.
13. Lazy Jacobian and Jacobian transpose vector/matrix multiplication.
14. Lazy Hessian and Hessian transpose vector/matrix multiplication.

A package author can choose to define any of the above automatically defined functions for his/her package in the following cases:
1. The default implementation is not efficient enough. For example, the `pushforward`'s and `pullback`'s default implementations using `jacobian` incur some additional arithmetic required for the encoding of both of these functions as Jacobians. A few savings can be made by defining the method for the backend directly.
2. To avoid control flow. The `value_and` versions of the functions uses control flow to avoid querying the primal value more than once when the function is called multiple times, e.g. when calculating the gradient of a multivariate function with forward-mode in chunks.

I tried to keep the restrictions minimal in my implementation. Looking forward to your feedback!

The main remaining items to do here are:
- [ ] Test the hessian functions
- [ ] Test the lazy operators
- [ ] Write documentation