### PR TITLE
Fixes gradient, Jacobian, Hessian, and vjp tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,8 @@ julia = "1"
 
 [extras]
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "FiniteDifferences"]
+test = ["Test", "FiniteDifferences", "Random"]

--- a/src/AbstractDifferentiation.jl
+++ b/src/AbstractDifferentiation.jl
@@ -51,7 +51,7 @@ function hessian(ab::AbstractBackend, f, xs...)
     # defined by ∂x∂x f, ∂y∂y f, in the case of a scalar valued function `f`.  
     hess = map((xs...,)) do x
         counter += 1
-        _f = _x->f(setindex!(deepcopy(xss),x,counter)...)
+        _f = _x->f(setindex!(deepcopy(xss),_x,counter)...)
         return jacobian(secondlowest(ab),(x,)-> begin
             return gradient(lowest(ab), _f, x)
             end, x)[1]
@@ -490,17 +490,13 @@ function define_pushforward_function_and_friends(fdef)
                     end
                 end
             elseif eltype(identity_like) <: AbstractMatrix
-                # needed for the computation of the Hessian
-                println("define_pushforward_function_and_friends")
-                @show identity_like
+                # needed for the computation of the Hessian and Jacobian
                 ret = hcat.(mapslices(identity_like[1], dims=1) do cols
                     # cols loop over basis states   
                     pf = pff((cols,))
-                    @show cols pf
                     if typeof(pf) <: AbstractVector
+                        # to make the hcat. work / get correct matrix-like, non-flat output dimension
                         return (pf, )
-                    elseif typeof(pf) <: AbstractMatrix
-                        return (transpose(pf), )
                     else
                         return pf
                     end

--- a/src/AbstractDifferentiation.jl
+++ b/src/AbstractDifferentiation.jl
@@ -154,6 +154,10 @@ function value_and_pushforward_function(
         @assert ds isa Tuple && length(ds) == length(xs)
         local value
         primalcalled = false
+        if ab isa AbstractFiniteDifference
+            value = primalvalue(ab, nothing, f, xs)
+            primalcalled = true
+        end
         pf = pushforward_function(lowest(ab), (_xs...,) -> begin
             vs = f(_xs...)
             if !primalcalled
@@ -208,6 +212,10 @@ function value_and_pullback_function(
     return (ws) -> begin
         local value
         primalcalled = false
+        if ab isa AbstractFiniteDifference
+            value = primalvalue(ab, nothing, f, xs)
+            primalcalled = true
+        end
         if ws === nothing
             vs = f(xs...)
             if !primalcalled

--- a/src/AbstractDifferentiation.jl
+++ b/src/AbstractDifferentiation.jl
@@ -278,8 +278,26 @@ struct LazyGradient{B, F, X}
     f::F
     xs::X
 end
-Base.:*(d::LazyGradient, y) = gradient(d.ab, d.f, d.xs...) * y
-Base.:*(y, d::LazyGradient) = y * gradient(d.ab, d.f, d.xs...)
+Base.:*(d::LazyGradient, y) = gradient(d.backend, d.f, d.xs...) * y
+Base.:*(y, d::LazyGradient) = y * gradient(d.backend, d.f, d.xs...)
+
+
+function Base.:*(d::LazyGradient, y::Union{Number,Tuple})
+    if d.xs isa Tuple
+        return gradient(d.backend, d.f, d.xs...) .* y
+    else
+        return gradient(d.backend, d.f, d.xs) .* y
+    end
+end
+
+function Base.:*(y::Union{Number,Tuple}, d::LazyGradient)
+    if d.xs isa Tuple
+        return y .* gradient(d.backend, d.f, d.xs...)
+    else
+        return y .* gradient(d.backend, d.f, d.xs)
+    end
+end
+
 
 struct LazyJacobian{B, F, X}
     backend::B

--- a/src/AbstractDifferentiation.jl
+++ b/src/AbstractDifferentiation.jl
@@ -359,6 +359,19 @@ function define_pushforward_function_and_friends(fdef)
                         pff(cols)
                     end
                 end
+            elseif eltype(identity_like) <: AbstractMatrix
+                ret = hcat.(mapslices(identity_like[1], dims=1) do cols
+                    pf = pff((cols,))
+                    if typeof(pf) <: AbstractVector
+                        return (pf, )
+                    elseif typeof(pf) <: AbstractMatrix
+                        return (transpose(pf), )
+                    else
+                        return pf
+                    end
+                end ...)
+                return ret isa Tuple ? ret : (ret,)
+
             else
                 return pff(identity_like)
             end

--- a/src/AbstractDifferentiation.jl
+++ b/src/AbstractDifferentiation.jl
@@ -382,6 +382,10 @@ function define_pullback_function_and_friends(fdef)
                         value_and_pbf(cols)[2]'
                     end
                 end
+            elseif eltype(identity_like) <: AbstractMatrix
+                return vcat.(mapslices(identity_like[1], dims=1) do cols
+                    adjoint.(value_and_pbf((cols,))[2])
+                end ...)
             else
                 return adjoint.(value_and_pbf(identity_like)[2])
             end

--- a/src/AbstractDifferentiation.jl
+++ b/src/AbstractDifferentiation.jl
@@ -54,6 +54,10 @@ end
 function value_and_jacobian(ab::AbstractBackend, f, xs...)
     local value
     primalcalled = false
+    if ab isa AbstractFiniteDifference
+        value = primalvalue(ab, nothing, f, xs)
+        primalcalled = true
+    end
     jacs = jacobian(lowest(ab), (_xs...,) -> begin
         v = f(_xs...)
         if !primalcalled
@@ -62,11 +66,16 @@ function value_and_jacobian(ab::AbstractBackend, f, xs...)
         end
         return v
     end, xs...)
+
     return value, jacs
 end
 function value_and_hessian(ab::AbstractBackend, f, xs...)
     local value
     primalcalled = false
+    if ab isa AbstractFiniteDifference
+        value = primalvalue(ab, nothing, f, xs)
+        primalcalled = true
+    end
     hess = jacobian(secondlowest(ab), (_xs...,) -> begin
         v, g = value_and_gradient(lowest(ab), f, _xs...)
         if !primalcalled

--- a/src/AbstractDifferentiation.jl
+++ b/src/AbstractDifferentiation.jl
@@ -54,7 +54,7 @@ end
 function value_and_jacobian(ab::AbstractBackend, f, xs...)
     local value
     primalcalled = false
-    if ab isa AbstractFiniteDifference
+    if lowest(ab) isa AbstractFiniteDifference
         value = primalvalue(ab, nothing, f, xs)
         primalcalled = true
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -161,7 +161,6 @@ end
         @testset "Jacobian" begin
             test_fdm_jacobians(fdm_backend1)
             test_fdm_jacobians(fdm_backend2)
-            # Errors
             test_fdm_jacobians(fdm_backend3)
         end
         @testset "Hessian" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -360,7 +360,7 @@ function test_fdm_lazy_jacobians(fdm_backend)
             identity_like_i .* v
         end
 
-        res = map(v->lazyjac*v, vaug)
+        res = map(v->(lazyjac*v)[1], vaug)
     else
         res = lazyjac*v
     end


### PR DESCRIPTION
Current test status:
```julia
Test Summary:              | Pass  Fail  Error  Total
AbstractDifferentiation.jl |  103     1      1    105
  FiniteDifferences        |  103     1      1    105
    Derivative             |   12                  12
    Gradient               |   18                  18
    Jacobian               |   18                  18
    Hessian                |   30                  30
    jvp                    |    7     1      1      9
    j′vp                   |   18                  18
```
There are basically two fixes:
- FiniteDifferences mutates the input `x` to compute the gradients, so the value was computed wrongly. 
- when the identity was an `AbstractMatrix` it didn't loop over its columns but vectorized the entire matrix which lead to a dimension error. 

It remains to fix the jvp case.
```julia
test_fdm_jvp(fdm_backend1) # passes
test_fdm_jvp(fdm_backend2) # fails
test_fdm_jvp(fdm_backend3) # fails
```

For example, in `fdm_backend2`
```julia
v = (rand(length(xvec)), rand(length(yvec)))
pf1 = AD.pushforward_function(fdm_backend2, fjac, xvec, yvec)(v) 
```
results in a *single* output vector instead of a *tuple of two*  output vectors.
