### PR TITLE
Use value_and_pullback_function as a primitive

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractDifferentiation"
 uuid = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"
 authors = ["Mohamed Tarek <mohamed82008@gmail.com> and contributors"]
-version = "0.3.0"
+version = "0.4.0-DEV"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/AbstractDifferentiation.jl
+++ b/src/AbstractDifferentiation.jl
@@ -505,8 +505,8 @@ macro primitive(expr)
     name = fdef[:name]
     if name == :pushforward_function
         return define_pushforward_function_and_friends(fdef) |> esc
-    elseif name == :pullback_function
-        return define_pullback_function_and_friends(fdef) |> esc
+    elseif name == :value_and_pullback_function
+        return define_value_and_pullback_function_and_friends(fdef) |> esc
     elseif name == :jacobian
         return define_jacobian_and_friends(fdef) |> esc
     elseif name == :primal_value
@@ -558,8 +558,8 @@ function define_pushforward_function_and_friends(fdef)
     return funcs
 end
 
-function define_pullback_function_and_friends(fdef)
-    fdef[:name] = :(AbstractDifferentiation.pullback_function)
+function define_value_and_pullback_function_and_friends(fdef)
+    fdef[:name] = :(AbstractDifferentiation.value_and_pullback_function)
     args = fdef[:args]
     funcs = quote
         $(ExprTools.combinedef(fdef))


### PR DESCRIPTION
Fixes #34. Breaking change marked with `-DEV` version number in case it is merged before #35.