### PR TITLE
 Implement backend for FiniteDifferences

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractDifferentiation"
 uuid = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"
 authors = ["Mohamed Tarek <mohamed82008@gmail.com> and contributors"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/AbstractDifferentiation.jl
+++ b/src/AbstractDifferentiation.jl
@@ -642,6 +642,7 @@ end
 
 function __init__()
     @require ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210" include("forwarddiff.jl")
+    @require FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000" include("finitedifferences.jl")
 end
 
 end

--- a/src/finitedifferences.jl
+++ b/src/finitedifferences.jl
@@ -22,14 +22,6 @@ FiniteDifferencesBackend() = FiniteDifferencesBackend(FiniteDifferences.central_
     return FiniteDifferences.jacobian(ba.method, f, xs...)
 end
 
-function derivative(ba::FiniteDifferencesBackend, f, xs::Number...)
-    return pullback_function(ba, f, xs...)(true)
-end
-
-function gradient(ba::FiniteDifferencesBackend, f, xs...)
-    return FiniteDifferences.grad(ba.method, f, xs...)
-end
-
 function pushforward_function(ba::FiniteDifferencesBackend, f, xs...)
     return function pushforward(vs)
         ws = FiniteDifferences.jvp(ba.method, f, tuple.(xs, vs)...)

--- a/src/finitedifferences.jl
+++ b/src/finitedifferences.jl
@@ -1,0 +1,44 @@
+using .FiniteDifferences: FiniteDifferences
+
+"""
+    FiniteDifferencesBackend{M}
+
+AD backend that uses forward mode with FiniteDifferences.jl.
+
+The type parameter `M` is the type of the method used to perform finite differences.
+"""
+struct FiniteDifferencesBackend{M} <: AbstractFiniteDifference
+    method::M
+end
+
+"""
+    FiniteDifferencesBackend(method=FiniteDifferences.central_fdm(5, 1))
+
+Create an AD backend that uses forward mode with FiniteDifferences.jl.
+"""
+FiniteDifferencesBackend() = FiniteDifferencesBackend(FiniteDifferences.central_fdm(5, 1))
+
+@primitive function jacobian(ba::FiniteDifferencesBackend, f, xs...)
+    return FiniteDifferences.jacobian(ba.method, f, xs...)
+end
+
+function derivative(ba::FiniteDifferencesBackend, f, xs::Number...)
+    return pullback_function(ba, f, xs...)(true)
+end
+
+function gradient(ba::FiniteDifferencesBackend, f, xs...)
+    return FiniteDifferences.grad(ba.method, f, xs...)
+end
+
+function pushforward_function(ba::FiniteDifferencesBackend, f, xs...)
+    return function pushforward(vs)
+        ws = FiniteDifferences.jvp(ba.method, f, tuple.(xs, vs)...)
+        return length(xs) == 1 ? (ws,) : ws
+    end
+end
+
+function pullback_function(ba::FiniteDifferencesBackend, f, xs...)
+    function pullback(vs)
+        return FiniteDifferences.j′vp(ba.method, f, vs, xs...)
+    end
+end

--- a/src/finitedifferences.jl
+++ b/src/finitedifferences.jl
@@ -22,8 +22,6 @@ FiniteDifferencesBackend() = FiniteDifferencesBackend(FiniteDifferences.central_
     return FiniteDifferences.jacobian(ba.method, f, xs...)
 end
 
-derivative(ba::FiniteDifferencesBackend, f, x::Number) = ba.method(f, x)
-
 function pushforward_function(ba::FiniteDifferencesBackend, f, xs...)
     return function pushforward(vs)
         ws = FiniteDifferences.jvp(ba.method, f, tuple.(xs, vs)...)

--- a/src/finitedifferences.jl
+++ b/src/finitedifferences.jl
@@ -22,6 +22,8 @@ FiniteDifferencesBackend() = FiniteDifferencesBackend(FiniteDifferences.central_
     return FiniteDifferences.jacobian(ba.method, f, xs...)
 end
 
+derivative(ba::FiniteDifferencesBackend, f, x::Number) = ba.method(f, x)
+
 function pushforward_function(ba::FiniteDifferencesBackend, f, xs...)
     return function pushforward(vs)
         ws = FiniteDifferences.jvp(ba.method, f, tuple.(xs, vs)...)

--- a/test/finitedifferences.jl
+++ b/test/finitedifferences.jl
@@ -1,0 +1,47 @@
+using AbstractDifferentiation
+using Test
+using FiniteDifferences
+
+@testset "FiniteDifferencesBackend" begin
+    method = FiniteDifferences.central_fdm(6, 1)
+    # `central_fdm(5, 1)` is not type-inferrable, so only check inferrability
+    # with user-specified method
+    backends = [
+        AD.FiniteDifferencesBackend(),
+        @inferred(AD.FiniteDifferencesBackend(method)),
+    ]
+    @test backends[2].method === method
+
+    @testset for backend in backends
+        @testset "Derivative" begin
+            test_derivatives(backend)
+        end
+        @testset "Gradient" begin
+            test_gradients(backend)
+        end
+        @testset "Jacobian" begin
+            test_jacobians(backend)
+        end
+        @testset "Hessian" begin
+            test_hessians(backend)
+        end
+        @testset "jvp" begin
+            test_jvp(backend; vaugmented=true)
+        end
+        @testset "j′vp" begin
+            test_j′vp(backend)
+        end
+        @testset "Lazy Derivative" begin
+            test_lazy_derivatives(backend)
+        end
+        @testset "Lazy Gradient" begin
+            test_lazy_gradients(backend)
+        end
+        @testset "Lazy Jacobian" begin
+            test_lazy_jacobians(backend; vaugmented=true)
+        end
+        @testset "Lazy Hessian" begin
+            test_lazy_hessians(backend)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,4 +5,5 @@ using Test
     include("test_utils.jl")
     include("defaults.jl")
     include("forwarddiff.jl")
+    include("finitedifferences.jl")
 end


### PR DESCRIPTION
This PR implements a backend for FiniteDifferences.jl. It basically combines the 3 declarations in the tests into 1, with generalization of `pullback_function` to multi-output functions.

Informal benchmarks showed that all three of these methods were necessary for speed. They also showed that with these defined, our default `gradient` and multi-arg `derivative` methods are faster than custom overloads using `jvp` and `grad`. A single-arg `derivative` method was faster than our default, yet for some reason it was less accurate.