### PR TITLE
Make ForwardDiffBackend an AbstractForwardMode

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractDifferentiation"
 uuid = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"
 authors = ["Mohamed Tarek <mohamed82008@gmail.com> and contributors"]
-version = "0.3.0"
+version = "0.4.0-DEV"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/forwarddiff.jl
+++ b/src/forwarddiff.jl
@@ -10,7 +10,7 @@ The type parameter `CS` denotes the chunk size of the differentiation algorithm.
 
 See also: [ForwardDiff.jl: Configuring Chunk Size](https://juliadiff.org/ForwardDiff.jl/dev/user/advanced/#Configuring-Chunk-Size)
 """
-struct ForwardDiffBackend{CS} <: AbstractBackend end
+struct ForwardDiffBackend{CS} <: AbstractForwardMode end
 
 """
     ForwardDiffBackend(; chunksize::Union{Val,Nothing}=nothing)

--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -8,6 +8,8 @@ using ForwardDiff
         @inferred(AD.ForwardDiffBackend(; chunksize=Val{1}()))
     ]
     @testset for backend in backends
+        @test backend isa AD.AbstractForwardMode
+
         @testset "Derivative" begin
             test_derivatives(backend)
         end


### PR DESCRIPTION
#20 failed to make `ForwardDiffBackend` subtype `AbstractForwardMode`. This PR fixes this.