### PR TITLE
Retrieve pullback only once for ReverseRuleConfigBackend

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractDifferentiation"
 uuid = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"
 authors = ["Mohamed Tarek <mohamed82008@gmail.com> and contributors"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/ruleconfig.jl
+++ b/src/ruleconfig.jl
@@ -3,17 +3,13 @@
 
 AD backend that uses reverse mode with any ChainRules-compatible reverse-mode AD package.
 """
-struct ReverseRuleConfigBackend{RC <: RuleConfig} <: AbstractReverseMode
+struct ReverseRuleConfigBackend{RC<:RuleConfig{>:HasReverseMode}} <: AbstractReverseMode
     ruleconfig::RC
 end
 
 AD.@primitive function pullback_function(ab::ReverseRuleConfigBackend, f, xs...)
-    return (vs) -> begin
-        _, back = rrule_via_ad(ab.ruleconfig, f, xs...)
-        if vs isa Tuple && length(vs) === 1
-            return Base.tail(back(vs[1]))
-        else
-            return Base.tail(back(vs))
-        end
-    end
+    _, back = rrule_via_ad(ab.ruleconfig, f, xs...)
+    pullback(vs) = Base.tail(back(vs))
+    pullback(vs::Tuple{Any}) = Base.tail(back(first(vs))
+    return pullback
 end

--- a/src/ruleconfig.jl
+++ b/src/ruleconfig.jl
@@ -3,7 +3,7 @@
 
 AD backend that uses reverse mode with any ChainRules-compatible reverse-mode AD package.
 """
-struct ReverseRuleConfigBackend{RC<:RuleConfig{>:HasReverseMode}} <: AbstractReverseMode
+struct ReverseRuleConfigBackend{RC<:RuleConfig{>:ChainRulesCore.HasReverseMode}} <: AbstractReverseMode
     ruleconfig::RC
 end
 


### PR DESCRIPTION
This PR contains the suggestions in https://github.com/JuliaDiff/AbstractDifferentiation.jl/pull/49#pullrequestreview-877962490.

Most importantly, the CR pullback function is only computed once and reused. Moreover, the type parameter is restricted to `RuleConfig`s with reverse mode capability, in line with the intention in the docstring.