### PR TITLE
add do-block-friendly forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ julia> AD.gradient(ab, f, rand(10))
 ([0.07163448353282538, 0.08520350535348796, 0.09675622487503996, 0.1522744408520505, 0.12174662595572318, 0.07996969757526722, 0.07832665607158593, 0.11001685581681672, 0.06691909637037166, 0.1371524135968315],)
 ```
 
+All of the backend-dependent functions in this package also have a [do-block](https://docs.julialang.org/en/v1/manual/functions/#Do-Block-Syntax-for-Function-Arguments)-friendly form where the `AbstractBackend` object is specified via the `backend` keyword argument and the function to be differentiated is the first argument. For example, the above call can also be written as:
+
+```julia
+julia> AD.gradient(rand(10); backend=AD.ZygoteBackend()) do x
+           log(sum(exp, x))
+       end
+```
+
 For higher order derivatives, you can build higher order backends using `AD.HigherOrderBackend`. For instance, let `ab_f` be a forward-mode automatic differentiation backend and let `ab_r` be a reverse-mode automatic differentiation backend. To construct a higher order backend for doing forward-over-reverse-mode automatic differentiation, use `AD.HigherOrderBackend((ab_f, ab_r))`. To construct a higher order backend for doing reverse-over-forward-mode automatic differentiation, use `AD.HigherOrderBackend((ab_r, ab_f))`.
 
 ## Backend-agnostic interface

--- a/src/AbstractDifferentiation.jl
+++ b/src/AbstractDifferentiation.jl
@@ -43,13 +43,22 @@ function derivative(ab::AbstractBackend, f, xs::Number...)
         return (der,)
     end
 end
+function derivative(f, xs::Number...; backend::AbstractBackend)
+    return derivative(backend, f, xs...)
+end
 
 function gradient(ab::AbstractBackend, f, xs...)
     return reshape.(adjoint.(jacobian(lowest(ab), f, xs...)),size.(xs))
 end
+function gradient(f, xs...; backend::AbstractBackend)
+    return gradient(backend, f, xs...)
+end
 function jacobian(ab::AbstractBackend, f, xs...) end
 function jacobian(ab::HigherOrderBackend, f, xs...) 
-    jacobian(lowest(ab), f, xs...)
+    return jacobian(lowest(ab), f, xs...)
+end
+function jacobian(f, xs...; backend::AbstractBackend)
+    return jacobian(backend, f, xs...)
 end
 
 function hessian(ab::AbstractBackend, f, x)
@@ -62,14 +71,23 @@ function hessian(ab::AbstractBackend, f, x)
         gradient(lowest(ab), f, x)[1] # gradient returns a tuple
     end, x)
 end
+function hessian(f, x; backend::AbstractBackend)
+    return hessian(backend, f, x)
+end
 
 function value_and_derivative(ab::AbstractBackend, f, xs::Number...)
     value, jacs = value_and_jacobian(lowest(ab), f, xs...)
     return value[1], getindex.(jacs, 1)
 end
+function value_and_derivative(f, xs::Number...; backend::AbstractBackend)
+    return value_and_derivative(backend, f, xs...)
+end
 function value_and_gradient(ab::AbstractBackend, f, xs...)
     value, jacs = value_and_jacobian(lowest(ab), f, xs...)
     return value, reshape.(adjoint.(jacs),size.(xs))
+end
+function value_and_gradient(f, xs...; backend::AbstractBackend)
+    return value_and_gradient(backend, f, xs...)
 end
 function value_and_jacobian(ab::AbstractBackend, f, xs...)
     local value
@@ -88,6 +106,9 @@ function value_and_jacobian(ab::AbstractBackend, f, xs...)
     end, xs...)
 
     return value, jacs
+end
+function value_and_jacobian(f, xs...; backend::AbstractBackend)
+    return value_and_jacobian(backend, f, xs...)
 end
 function value_and_hessian(ab::AbstractBackend, f, x)
     if x isa Tuple
@@ -130,6 +151,9 @@ function value_and_hessian(ab::HigherOrderBackend, f, x)
     end, x)
     return value, hess
 end
+function value_and_hessian(f, x; backend::AbstractBackend)
+    return value_and_hessian(backend, f, x)
+end
 function value_gradient_and_hessian(ab::AbstractBackend, f, x)
     if x isa Tuple
         # only support computation of Hessian for functions with single input argument
@@ -166,6 +190,9 @@ function value_gradient_and_hessian(ab::HigherOrderBackend, f, x)
     end, x)
     return value, (grads,), hess
 end
+function value_gradient_and_hessian(f, x; backend::AbstractBackend)
+    return value_gradient_and_hessian(backend, f, x)
+end
 
 function pushforward_function(
     ab::AbstractBackend,
@@ -185,6 +212,9 @@ function pushforward_function(
             end
         end, _zero.(xs, ds)...)
     end
+end
+function pushforward_function(f, xs...; backend::AbstractBackend)
+    return pushforward_function(backend, f, xs...)
 end
 function value_and_pushforward_function(
     ab::AbstractBackend,
@@ -213,6 +243,9 @@ function value_and_pushforward_function(
         
         return value, pf
     end
+end
+function value_and_pushforward_function(f, xs...; backend::AbstractBackend)
+    return value_and_pushforward_function(backend, f, xs...)
 end
 
 _zero(::Number, d::Number) = zero(d)
@@ -245,6 +278,9 @@ function pullback_function(ab::AbstractBackend, f, xs...)
         end, xs...)
     end
 end
+function pullback_function(f, xs...; backend::AbstractBackend)
+    return pullback_function(backend, f, xs...)
+end
 function value_and_pullback_function(
     ab::AbstractBackend,
     f,
@@ -275,6 +311,9 @@ function value_and_pullback_function(
         end, xs...)(ws)
         return value, pb
     end
+end
+function value_and_pullback_function(f, xs...; backend::AbstractBackend)
+    return value_and_pullback_function(backend, f, xs...)
 end
 
 struct LazyDerivative{B, F, X}
@@ -465,14 +504,26 @@ end
 function lazy_derivative(ab::AbstractBackend, f, xs::Number...)
     return LazyDerivative(ab, f, xs)
 end
+function lazy_derivative(f, xs::Number...; backend::AbstractBackend)
+    return LazyDerivative(backend, f, xs)
+end
 function lazy_gradient(ab::AbstractBackend, f, xs...)
     return LazyGradient(ab, f, xs)
+end
+function lazy_gradient(f, xs...; backend::AbstractBackend)
+    return LazyGradient(backend, f, xs)
 end
 function lazy_hessian(ab::AbstractBackend, f, xs...)
     return LazyHessian(ab, f, xs)
 end
+function lazy_hessian(f, xs...; backend::AbstractBackend)
+    return LazyHessian(backend, f, xs)
+end
 function lazy_jacobian(ab::AbstractBackend, f, xs...)
     return LazyJacobian(ab, f, xs)
+end
+function lazy_jacobian(f, xs...; backend::AbstractBackend)
+    return LazyJacobian(backend, f, xs)
 end
 
 struct D{B, F}


### PR DESCRIPTION
I also really want do-block with this package and the suggestion here https://github.com/JuliaDiff/AbstractDifferentiation.jl/issues/33#issuecomment-1018923309 seems like the best one to me, so I implemented it in this PR should the devs like it. 

For reference, I think the other options are 

1. switch the order and break everything (:vomiting_face:) 
2. allow both orders with dispatch (breaks the only-one-way-to-do-something rule, which I think is worse than this PR but honestly only very marginally worse, so maybe worth considering, I'm not married to this PR, I just want do-block :grin: )
