### PR TITLE
Do not load StaticArrays in ForwardDiff backend

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractDifferentiation"
 uuid = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"
 authors = ["Mohamed Tarek <mohamed82008@gmail.com> and contributors"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/forwarddiff.jl
+++ b/src/forwarddiff.jl
@@ -1,4 +1,4 @@
-using .ForwardDiff: ForwardDiff, DiffResults, StaticArrays
+using .ForwardDiff: ForwardDiff, DiffResults
 
 """
     ForwardDiffBackend{CS}


### PR DESCRIPTION
It was not obvious to me why StaticArrays is loaded in forwarddiff.jl, so let's try to remove it.

Fixes #73.