### PR TITLE
New Zygote context in every call to `AD.pullback_function`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractDifferentiation"
 uuid = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"
 authors = ["Mohamed Tarek <mohamed82008@gmail.com> and contributors"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -24,7 +24,7 @@ AbstractDifferentiationFiniteDifferencesExt = "FiniteDifferences"
 AbstractDifferentiationForwardDiffExt = ["DiffResults", "ForwardDiff"]
 AbstractDifferentiationReverseDiffExt = ["DiffResults", "ReverseDiff"]
 AbstractDifferentiationTrackerExt = "Tracker"
-AbstractDifferentiationZygoteExt = "Zygote"
+AbstractDifferentiationZygoteExt = ["ChainRulesCore", "Zygote"]
 
 [compat]
 ChainRulesCore = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ AbstractDifferentiationFiniteDifferencesExt = "FiniteDifferences"
 AbstractDifferentiationForwardDiffExt = ["DiffResults", "ForwardDiff"]
 AbstractDifferentiationReverseDiffExt = ["DiffResults", "ReverseDiff"]
 AbstractDifferentiationTrackerExt = "Tracker"
-AbstractDifferentiationZygoteExt = ["ChainRulesCore", "Zygote"]
+AbstractDifferentiationZygoteExt = "Zygote"
 
 [compat]
 ChainRulesCore = "1"

--- a/ext/AbstractDifferentiationChainRulesCoreExt.jl
+++ b/ext/AbstractDifferentiationChainRulesCoreExt.jl
@@ -4,7 +4,7 @@ import AbstractDifferentiation as AD
 using ChainRulesCore: ChainRulesCore
 
 AD.@primitive function pullback_function(ba::AD.ReverseRuleConfigBackend, f, xs...)
-    _, back = ChainRulesCore.rrule_via_ad(ba.ruleconfig, f, xs...)
+    _, back = ChainRulesCore.rrule_via_ad(AD.ruleconfig(ba), f, xs...)
     pullback(vs) = Base.tail(back(vs))
     pullback(vs::Tuple{Any}) = Base.tail(back(first(vs)))
     return pullback

--- a/ext/AbstractDifferentiationZygoteExt.jl
+++ b/ext/AbstractDifferentiationZygoteExt.jl
@@ -6,16 +6,12 @@ if AD.EXTENSIONS_SUPPORTED
 else
     using ..Zygote: Zygote
 end
-using ChainRulesCore: ChainRulesCore
 
 AD.ZygoteBackend() = AD.ReverseRuleConfigBackend(Zygote.ZygoteRuleConfig())
 
 # Context should not persist between different AD calls: fixes #69
-function AD.pullback_function(ba::AD.ReverseRuleConfigBackend{<:Zygote.ZygoteRuleConfig}, f, xs...)
-    _, back = ChainRulesCore.rrule_via_ad(Zygote.ZygoteRuleConfig(), f, xs...)
-    pullback(vs) = Base.tail(back(vs))
-    pullback(vs::Tuple{Any}) = Base.tail(back(first(vs)))
-    return pullback
+function AD.ruleconfig(::AD.ReverseRuleConfigBackend{<:Zygote.ZygoteRuleConfig})
+    return Zygote.ZygoteRuleConfig()
 end
 
 end # module

--- a/ext/AbstractDifferentiationZygoteExt.jl
+++ b/ext/AbstractDifferentiationZygoteExt.jl
@@ -6,7 +6,16 @@ if AD.EXTENSIONS_SUPPORTED
 else
     using ..Zygote: Zygote
 end
+using ChainRulesCore: ChainRulesCore
 
 AD.ZygoteBackend() = AD.ReverseRuleConfigBackend(Zygote.ZygoteRuleConfig())
+
+# Context should not persist between different AD calls: fixes #69
+function AD.pullback_function(ba::AD.ReverseRuleConfigBackend{<:Zygote.ZygoteRuleConfig}, f, xs...)
+    _, back = ChainRulesCore.rrule_via_ad(Zygote.ZygoteRuleConfig(), f, xs...)
+    pullback(vs) = Base.tail(back(vs))
+    pullback(vs::Tuple{Any}) = Base.tail(back(first(vs)))
+    return pullback
+end
 
 end # module

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -61,6 +61,11 @@ struct ReverseRuleConfigBackend{RC} <: AbstractReverseMode
     ruleconfig::RC
 end
 
+# internal function for extracting the rule config
+# falls back to returning the wrapped `ruleconfig` but can be specialized
+# e.g., for Zygote to fix #69
+ruleconfig(ba::ReverseRuleConfigBackend) = ba.ruleconfig
+
 """
     ZygoteBackend()
 

--- a/test/ruleconfig.jl
+++ b/test/ruleconfig.jl
@@ -30,4 +30,26 @@ using Zygote
             test_lazy_jacobians(backend)
         end
     end
+
+    # issue #69
+    @testset "Zygote context" begin
+        ad = AD.ZygoteBackend()
+
+        # example in #69: context is not mutated
+        @test ad.ruleconfig.context.cache === nothing
+        @test AD.derivative(ad, exp, 1.0) === (exp(1.0),)
+        @test ad.ruleconfig.context.cache === nothing
+        @test AD.derivative(ad, exp, 1.0) === (exp(1.0),)
+        @test ad.ruleconfig.context.cache === nothing
+
+        # Jacobian computation still works
+        # https://github.com/JuliaDiff/AbstractDifferentiation.jl/pull/70#issuecomment-1449481724
+        function f(x, a)
+           r = Ref(x)
+           r[] = r[] + r[]
+           r[] = r[] * a
+           r[]
+        end
+        @test AD.jacobian(ad, f, [1, 2, 3], 3) == ([6.0 0.0 0.0; 0.0 6.0 0.0; 0.0 0.0 6.0], [2.0, 4.0, 6.0])
+    end
 end


### PR DESCRIPTION
Alternative to #76 that I had in mind when writing https://github.com/JuliaDiff/AbstractDifferentiation.jl/pull/76#pullrequestreview-1323649955.

In contrast to #76, with this PR `ZygoteBackend` would still be a `ReverseRuleConfigBackend`, and hence the behaviour of `ZygoteBackend` and `ReverseRuleConfigBackend(Zygote.ZygoteRuleConfig())` would not differ.

Fixes #69. Closes #70. Closes #76.