### PR TITLE
Remove the jacobian and primal_value primitives

### DIFF
--- a/ext/AbstractDifferentiationFiniteDifferencesExt.jl
+++ b/ext/AbstractDifferentiationFiniteDifferencesExt.jl
@@ -15,7 +15,7 @@ Create an AD backend that uses forward mode with FiniteDifferences.jl.
 """
 AD.FiniteDifferencesBackend() = AD.FiniteDifferencesBackend(FiniteDifferences.central_fdm(5, 1))
 
-AD.@primitive function jacobian(ba::AD.FiniteDifferencesBackend, f, xs...)
+function AD.jacobian(ba::AD.FiniteDifferencesBackend, f, xs...)
     return FiniteDifferences.jacobian(ba.method, f, xs...)
 end
 

--- a/ext/AbstractDifferentiationReverseDiffExt.jl
+++ b/ext/AbstractDifferentiationReverseDiffExt.jl
@@ -14,7 +14,7 @@ AD.primal_value(x::ReverseDiff.TrackedReal) = ReverseDiff.value(x)
 AD.primal_value(x::AbstractArray{<:ReverseDiff.TrackedReal}) = ReverseDiff.value.(x)
 AD.primal_value(x::ReverseDiff.TrackedArray) = ReverseDiff.value(x)
 
-AD.@primitive function jacobian(ba::AD.ReverseDiffBackend, f, xs...)
+function AD.jacobian(ba::AD.ReverseDiffBackend, f, xs...)
     xs_arr = map(AD.asarray, xs)
     tape = ReverseDiff.JacobianTape(xs_arr) do (xs_arr...)
         xs_new = map(xs, xs_arr) do x, x_arr

--- a/src/AbstractDifferentiation.jl
+++ b/src/AbstractDifferentiation.jl
@@ -496,10 +496,6 @@ macro primitive(expr)
         return define_pushforward_function_and_friends(fdef) |> esc
     elseif name == :pullback_function
         return define_pullback_function_and_friends(fdef) |> esc
-    elseif name == :jacobian
-        return define_jacobian_and_friends(fdef) |> esc
-    elseif name == :primal_value
-        return define_primal_value(fdef) |> esc
     else
         throw("Unsupported AD primitive.")
     end
@@ -573,16 +569,6 @@ end
 
 _eachcol(a::Number) = (a,)
 _eachcol(a) = eachcol(a)
-
-function define_jacobian_and_friends(fdef)
-    fdef[:name] = :($(AbstractDifferentiation).jacobian)
-    return ExprTools.combinedef(fdef)
-end
-
-function define_primal_value(fdef)
-    fdef[:name] = :($(AbstractDifferentiation).primal_value)
-    return ExprTools.combinedef(fdef)
-end
 
 function identity_matrix_like(x)
     throw("The function `identity_matrix_like` is not defined for the type $(typeof(x)).")

--- a/test/defaults.jl
+++ b/test/defaults.jl
@@ -12,7 +12,7 @@ end
 FDMBackend1() = FDMBackend1(central_fdm(5, 1))
 const fdm_backend1 = FDMBackend1()
 # Minimal interface
-AD.@primitive function jacobian(ab::FDMBackend1, f, xs...)
+function AD.jacobian(ab::FDMBackend1, f, xs...)
     return FDM.jacobian(ab.alg, f, xs...)
 end
 
@@ -49,7 +49,7 @@ end
 ## ForwardDiff
 struct ForwardDiffBackend1 <: AD.AbstractForwardMode end
 const forwarddiff_backend1 = ForwardDiffBackend1()
-AD.@primitive function jacobian(ab::ForwardDiffBackend1, f, xs)
+function AD.jacobian(ab::ForwardDiffBackend1, f, xs)
     if xs isa Number
         return (ForwardDiff.derivative(f, xs),)
     elseif xs isa AbstractArray


### PR DESCRIPTION
The jacobian and the primal_value support for `@primitive` does not provide any benefit but IMO rather makes the code less readable (related also to https://github.com/JuliaDiff/AbstractDifferentiation.jl/issues/91): The macro version is equivalent to directly defining `AD.jacobian` or `AD.primal_value`.

Hence this PR proposes to remove support for `@primitive function jacobian` and `@primitive function primal_value` (which seems unused and untested).