### PR TITLE
Improve performance of `derivative` with FiniteDifferences and ForwardDiff

### DIFF
--- a/ext/AbstractDifferentiationFiniteDifferencesExt.jl
+++ b/ext/AbstractDifferentiationFiniteDifferencesExt.jl
@@ -32,4 +32,9 @@ function AD.pullback_function(ba::AD.FiniteDifferencesBackend, f, xs...)
     end
 end
 
+# Better performance: issue #87
+function AD.derivative(ba::AD.FiniteDifferencesBackend, f::TF, x::Real) where {TF<:Function}
+    return (ba.method(f, x),)
+end
+
 end # module

--- a/ext/AbstractDifferentiationForwardDiffExt.jl
+++ b/ext/AbstractDifferentiationForwardDiffExt.jl
@@ -41,6 +41,10 @@ AD.primal_value(x::AbstractArray{<:ForwardDiff.Dual}) = ForwardDiff.value.(x)
 
 # these implementations are more efficient than the fallbacks
 
+function AD.derivative(::AD.ForwardDiffBackend, f, x::Real)
+    return (ForwardDiff.derivative(f, x),)
+end
+
 function AD.gradient(ba::AD.ForwardDiffBackend, f, x::AbstractArray)
     cfg = ForwardDiff.GradientConfig(f, x, chunk(ba, x))
     return (ForwardDiff.gradient(f, x, cfg),)
@@ -50,7 +54,7 @@ function AD.jacobian(ba::AD.ForwardDiffBackend, f, x::AbstractArray)
     cfg = ForwardDiff.JacobianConfig(AD.asarray ∘ f, x, chunk(ba, x))
     return (ForwardDiff.jacobian(AD.asarray ∘ f, x, cfg),)
 end
-AD.jacobian(::AD.ForwardDiffBackend, f, x::Number) = (ForwardDiff.derivative(f, x),)
+AD.jacobian(::AD.ForwardDiffBackend, f, x::Real) = (ForwardDiff.derivative(f, x),)
 
 function AD.hessian(ba::AD.ForwardDiffBackend, f, x::AbstractArray)
     cfg = ForwardDiff.HessianConfig(f, x, chunk(ba, x))


### PR DESCRIPTION
Fixes #87. With this PR, the benchmark in #87 yields on my computer
```julia
julia> @benchmark with_AD(1.)
BenchmarkTools.Trial: 10000 samples with 960 evaluations.
 Range (min … max):  87.060 ns …  1.505 μs  ┊ GC (min … max): 0.00% … 88.90%
 Time  (median):     89.291 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   92.532 ns ± 30.948 ns  ┊ GC (mean ± σ):  0.75% ±  2.17%

  █▆▆▆▃▂ ▄▅▄▂▁▁▁ ▄▂▁▁                                       ▁ ▂
  ███████████████████▇▆▇▇█▇▇▇▇▆▅▆▅▅▅▅▄▄▃▃▄▄▁▆▃▁▃▄▃▃▅▃▃▁▁▄█▆▄█ █
  87.1 ns      Histogram: log(frequency) by time       138 ns <

 Memory estimate: 32 bytes, allocs estimate: 2.

julia> @benchmark without_AD(1.)
BenchmarkTools.Trial: 10000 samples with 961 evaluations.
 Range (min … max):  86.429 ns …  1.699 μs  ┊ GC (min … max): 0.00% … 91.77%
 Time  (median):     89.110 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   91.506 ns ± 35.367 ns  ┊ GC (mean ± σ):  0.90% ±  2.23%

  ▃█▇▃▃██▄▄▂▁   ▂▃▄▄▄▂▁▁       ▃▂                             ▂
  ████████████▇██████████▇██▇▇████▇███▆▆▅▂▅▄▅▇█████▅▅▆▆▅▆▅▂▃▆ █
  86.4 ns      Histogram: log(frequency) by time       113 ns <

 Memory estimate: 32 bytes, allocs estimate: 2.
```