### PR TITLE
Fix docstring for `value_and_pullback_function`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractDifferentiation"
 uuid = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"
 authors = ["Mohamed Tarek <mohamed82008@gmail.com> and contributors"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/AbstractDifferentiation.jl
+++ b/src/AbstractDifferentiation.jl
@@ -236,7 +236,7 @@ function pushforward_function(ab::AbstractBackend, f, xs...)
                 newx = only(xs) + ds * only(xds)
                 return f(newx)
             end
-        end,
+        end
         return jacobian(lowest(ab), pf_aux, _zero.(xs, ds)...)
     end
     return pf


### PR DESCRIPTION
Fix the docstring of `value_and_pullback_function` to solve #124 and #119

Clarify that 
- `value_and_pushforward_function` means (value and pushforward) function
- `value_and_pullback_function` means value and (pullback function)

Name some anonymous functions in the process to make the code more readable
